### PR TITLE
fix: token expiry for authorised routes during testing

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -128,6 +128,10 @@ func (a *Auth) VerifyToken(w http.ResponseWriter, r *http.Request) (string, *Cla
 		return []byte(a.Secret), nil
 	})
 
+	// log.Default().Print("Token: ", token)
+	// log.Default().Println("Issued at ", claims.IssuedAt)
+	// log.Default().Println("Expires at ", claims.ExpiresAt)
+
 	if err != nil {
 		return "", nil, err
 	}

--- a/internal/tests/files_test.go
+++ b/internal/tests/files_test.go
@@ -50,7 +50,7 @@ func TestValidUploadFilepath(t *testing.T) {
 		assert.NoError(t, err)
 	
 		// Send a request to the upload file api endpoint
-		_, status, err := CreateMockRequest(uploadFilePayload, fmt.Sprintf("/api/files/upload/%d", int(testTutorial.ID)), "POST")
+		_, status, err := CreateTeachingAssistantAuthenticatedMockRequest(uploadFilePayload, fmt.Sprintf("/api/files/upload/%d", int(testTutorial.ID)), "POST", testTeachingAssistant)
 		assert.NoError(t, err)
 		assert.Equal(t, http.StatusCreated, status)
 	
@@ -77,7 +77,7 @@ func TestInvalidWeekUploadFilepath(t *testing.T) {
 		assert.NoError(t, err)
 	
 		// Send a request to the upload file api endpoint
-		_, status, err := CreateMockRequest(uploadFilePayload, fmt.Sprintf("/api/files/upload/%d", int(testTutorial.ID)), "POST")
+		_, status, err := CreateTeachingAssistantAuthenticatedMockRequest(uploadFilePayload, fmt.Sprintf("/api/files/upload/%d", int(testTutorial.ID)), "POST", testTeachingAssistant)
 		assert.NoError(t, err)
 		assert.Equal(t, http.StatusBadRequest, status)
 	
@@ -104,7 +104,7 @@ func TestValidDeleteFilepath(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Send a request to the delete file api endpoint
-		_, status, err := CreateMockRequest(api.FilepathPayload{Filepath: uploadFilePayload.Filepath}, fmt.Sprintf("/api/files/delete/%d", int(testTutorial.ID)), "PATCH")
+		_, status, err := CreateTeachingAssistantAuthenticatedMockRequest(api.FilepathPayload{Filepath: uploadFilePayload.Filepath}, fmt.Sprintf("/api/files/delete/%d", int(testTutorial.ID)), "PATCH", testTeachingAssistant)
 		assert.NoError(t, err)
 		assert.Equal(t, http.StatusOK, status)
 	
@@ -131,7 +131,7 @@ func TestInvalidFilepathDeleteFilepath(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Send a request to the delete file api endpoint
-		_, status, err := CreateMockRequest(api.FilepathPayload{Filepath: "Invalid filepath"}, fmt.Sprintf("/api/files/delete/%d", int(testTutorial.ID)), "PATCH")
+		_, status, err := CreateTeachingAssistantAuthenticatedMockRequest(api.FilepathPayload{Filepath: "Invalid filepath"}, fmt.Sprintf("/api/files/delete/%d", int(testTutorial.ID)), "PATCH", testTeachingAssistant)
 		assert.NoError(t, err)
 		assert.Equal(t, http.StatusInternalServerError, status)
 	
@@ -162,7 +162,7 @@ func TestValidPrivateFile(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Send a request to the private file api endpoint
-		_, status, err := CreateMockRequest(api.FilepathPayload{Filepath: uploadFilePayload.Filepath}, fmt.Sprintf("/api/files/private/%d", int(testTutorial.ID)), "PATCH")
+		_, status, err := CreateTeachingAssistantAuthenticatedMockRequest(api.FilepathPayload{Filepath: uploadFilePayload.Filepath}, fmt.Sprintf("/api/files/private/%d", int(testTutorial.ID)), "PATCH", testTeachingAssistant)
 		assert.NoError(t, err)
 		assert.Equal(t, http.StatusOK, status)
 	
@@ -193,7 +193,7 @@ func TestInvalidFilepathPrivateFile(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Send a request to the private file api endpoint
-		_, status, err := CreateMockRequest(api.FilepathPayload{Filepath: "Invalid filepath"}, fmt.Sprintf("/api/files/private/%d", int(testTutorial.ID)), "PATCH")
+		_, status, err := CreateTeachingAssistantAuthenticatedMockRequest(api.FilepathPayload{Filepath: "Invalid filepath"}, fmt.Sprintf("/api/files/private/%d", int(testTutorial.ID)), "PATCH", testTeachingAssistant)
 		assert.NoError(t, err)
 		assert.Equal(t, http.StatusInternalServerError, status)
 	
@@ -229,7 +229,7 @@ func TestValidUnprivateFile(t *testing.T) {
 		database.DB.Save(tutorialFile)
 		
 		// Send a request to the private file api endpoint
-		_, status, err := CreateMockRequest(api.FilepathPayload{Filepath: uploadFilePayload.Filepath}, fmt.Sprintf("/api/files/unprivate/%d", int(testTutorial.ID)), "PATCH")
+		_, status, err := CreateTeachingAssistantAuthenticatedMockRequest(api.FilepathPayload{Filepath: uploadFilePayload.Filepath}, fmt.Sprintf("/api/files/unprivate/%d", int(testTutorial.ID)), "PATCH", testTeachingAssistant)
 		assert.NoError(t, err)
 		assert.Equal(t, http.StatusOK, status)
 	
@@ -265,7 +265,7 @@ func TestInvalidFilepathUnprivateFile(t *testing.T) {
 		database.DB.Save(tutorialFile)
 
 		// Send a request to the unprivate file api endpoint
-		_, status, err := CreateMockRequest(api.FilepathPayload{Filepath: "Invalid filepath"}, fmt.Sprintf("/api/files/unprivate/%d", int(testTutorial.ID)), "PATCH")
+		_, status, err := CreateTeachingAssistantAuthenticatedMockRequest(api.FilepathPayload{Filepath: "Invalid filepath"}, fmt.Sprintf("/api/files/unprivate/%d", int(testTutorial.ID)), "PATCH", testTeachingAssistant)
 		assert.NoError(t, err)
 		assert.Equal(t, http.StatusInternalServerError, status)
 	

--- a/internal/tests/main_test.go
+++ b/internal/tests/main_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 )
 
-var TestRouter = router.TestSetup()
+var TestRouter = router.Setup()
 
 func TestMain(m *testing.M) {
 	err := database.Connect(true)
@@ -27,6 +27,11 @@ func TestMain(m *testing.M) {
 	// if err != nil {
 	// 	log.Fatalln(err)
 	// }
+	// Initialise auth obj
+	err = auth.InitialiseAuthObj()
+	if err != nil {
+		log.Fatalln("Failed to initialise auth obj!", err)
+	}
 
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
- Initialises AuthObj during testing, allowing token expiry to be set correctly during testing